### PR TITLE
Fixed a typo in the syntax hint for updating rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ UPDATE [Table]
 SET [column1] = [value1], [column2] = [value2] 
 WHERE [Condition];
 
-UPDATE Athletes SET sport = 'Picklball' WHERE sport = 'pockleball';
+UPDATE Athletes SET sport = 'Pickleball' WHERE sport = 'pockleball';
 ```
 
 </details>


### PR DESCRIPTION
Changed 'Picklball' to 'Pickleball' so it doesn't recommend changing a typo in the row, 'pockleball', to another typo, 'picklball'.